### PR TITLE
feat: 인증 플로우 구현 (로그인/회원가입/닉네임설정)

### DIFF
--- a/app/src/main/java/unithon/helpjob/HelpJobNavGraph.kt
+++ b/app/src/main/java/unithon/helpjob/HelpJobNavGraph.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import unithon.helpjob.ui.auth.nickname.NicknameSetupScreen
 import unithon.helpjob.ui.auth.signin.SignInScreen
 import unithon.helpjob.ui.auth.signup.SignUpScreen
 import unithon.helpjob.ui.main.TempScreen
@@ -38,10 +39,16 @@ fun HelpJobNavGraph(
         // 회원가입 화면
         composable(route = HelpJobDestinations.SIGN_UP_ROUTE) {
             SignUpScreen(
-                onNavigateToSignIn = {
-                    navActions.navigateToSignIn()
-                },
-                onNavigateToOnboarding = {
+                onNavigateToNicknameSetup = {
+                    navActions.navigateToNicknameSetup()
+                }
+            )
+        }
+
+        // 닉네임 설정 화면
+        composable(route = HelpJobDestinations.NICKNAME_SETUP_ROUTE) {
+            NicknameSetupScreen(
+                onNicknameSet = {
                     navActions.navigateToOnboarding()
                 }
             )

--- a/app/src/main/java/unithon/helpjob/HelpJobNavGraph.kt
+++ b/app/src/main/java/unithon/helpjob/HelpJobNavGraph.kt
@@ -7,6 +7,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import unithon.helpjob.ui.auth.signin.SignInScreen
+import unithon.helpjob.ui.auth.signup.SignUpScreen
 import unithon.helpjob.ui.main.TempScreen
 
 @Composable
@@ -26,10 +27,22 @@ fun HelpJobNavGraph(
         composable(route = HelpJobDestinations.SIGN_IN_ROUTE) {
             SignInScreen(
                 onNavigateToSignUp = {
-                    // TODO: 회원가입 화면으로 이동
+                    navActions.navigateToSignUp()
                 },
                 onNavigateToMain = {
                     navActions.navigateToMain()
+                }
+            )
+        }
+
+        // 회원가입 화면
+        composable(route = HelpJobDestinations.SIGN_UP_ROUTE) {
+            SignUpScreen(
+                onNavigateToSignIn = {
+                    navActions.navigateToSignIn()
+                },
+                onNavigateToOnboarding = {
+                    navActions.navigateToOnboarding()
                 }
             )
         }
@@ -43,6 +56,6 @@ fun HelpJobNavGraph(
             )
         }
 
-        // TODO: 다른 화면들 추가
+        // TODO: Onboarding 화면 추가
     }
 }

--- a/app/src/main/java/unithon/helpjob/HelpJobNavGraph.kt
+++ b/app/src/main/java/unithon/helpjob/HelpJobNavGraph.kt
@@ -49,7 +49,7 @@ fun HelpJobNavGraph(
         composable(route = HelpJobDestinations.NICKNAME_SETUP_ROUTE) {
             NicknameSetupScreen(
                 onNicknameSet = {
-                    navActions.navigateToOnboarding()
+                    navActions.navigateToMain()
                 }
             )
         }

--- a/app/src/main/java/unithon/helpjob/HelpJobNavigation.kt
+++ b/app/src/main/java/unithon/helpjob/HelpJobNavigation.kt
@@ -9,6 +9,7 @@ import androidx.navigation.NavHostController
 object HelpJobScreens {
     const val SIGN_IN_SCREEN = "sign_in"
     const val SIGN_UP_SCREEN = "sign_up"
+    const val NICKNAME_SETUP_SCREEN = "nickname_setup"
     const val ONBOARDING_SCREEN = "onboarding"
     const val MAIN_SCREEN = "main"
 }
@@ -28,6 +29,7 @@ object HelpJobScreens {
 object HelpJobDestinations {
     const val SIGN_IN_ROUTE = HelpJobScreens.SIGN_IN_SCREEN
     const val SIGN_UP_ROUTE = HelpJobScreens.SIGN_UP_SCREEN
+    const val NICKNAME_SETUP_ROUTE = HelpJobScreens.NICKNAME_SETUP_SCREEN
     const val ONBOARDING_ROUTE = HelpJobScreens.ONBOARDING_SCREEN
     const val MAIN_ROUTE = HelpJobScreens.MAIN_SCREEN
 }
@@ -45,6 +47,12 @@ class HelpJobNavigationActions(private val navController: NavHostController) {
 
     fun navigateToSignUp() {
         navController.navigate(HelpJobDestinations.SIGN_UP_ROUTE)
+    }
+
+    fun navigateToNicknameSetup() {
+        navController.navigate(HelpJobDestinations.NICKNAME_SETUP_ROUTE) {
+            popUpTo(HelpJobDestinations.SIGN_UP_ROUTE) { inclusive = true }
+        }
     }
 
     fun navigateToOnboarding() {

--- a/app/src/main/java/unithon/helpjob/data/network/AuthInterceptor.kt
+++ b/app/src/main/java/unithon/helpjob/data/network/AuthInterceptor.kt
@@ -1,0 +1,53 @@
+package unithon.helpjob.data.network
+
+import android.content.Context
+import androidx.datastore.preferences.core.stringPreferencesKey
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+import unithon.helpjob.data.repository.dataStore
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AuthInterceptor @Inject constructor(
+    @ApplicationContext private val context: Context
+) : Interceptor {
+
+    private val tokenKey = stringPreferencesKey("auth_token")
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+
+        // 토큰이 필요없는 API들 (로그인, 회원가입 등)
+        val noAuthEndpoints = listOf(
+            "/api/member/sign-in",
+            "/api/member/sign-up"
+        )
+
+        if (noAuthEndpoints.any { request.url.encodedPath.contains(it) }) {
+            return chain.proceed(request)
+        }
+
+        // DataStore에서 직접 토큰 가져오기
+        val token = runBlocking {
+            context.dataStore.data
+                .map { preferences -> preferences[tokenKey] }
+                .firstOrNull()
+        }
+
+        // 토큰이 있으면 헤더에 추가
+        val authenticatedRequest = if (token != null) {
+            request.newBuilder()
+                .header("Authorization", "Bearer $token")
+                .build()
+        } else {
+            request
+        }
+
+        return chain.proceed(authenticatedRequest)
+    }
+}

--- a/app/src/main/java/unithon/helpjob/data/network/HelpJobApiService.kt
+++ b/app/src/main/java/unithon/helpjob/data/network/HelpJobApiService.kt
@@ -2,7 +2,6 @@ package unithon.helpjob.data.network
 
 import retrofit2.Response
 import retrofit2.http.Body
-import retrofit2.http.Header
 import retrofit2.http.POST
 import unithon.helpjob.data.model.request.*
 import unithon.helpjob.data.model.response.TokenResponse
@@ -21,13 +20,11 @@ interface HelpJobApiService {
 
     @POST(ApiConstants.SET_NICKNAME)
     suspend fun setNickname(
-        @Header("Authorization") token: String,
         @Body request: MemberNicknameReq
     ): Response<Unit>
 
     @POST(ApiConstants.SET_PROFILE)
     suspend fun setProfile(
-        @Header("Authorization") token: String,
         @Body request: MemberProfileReq
     ): Response<TokenResponse>
 }

--- a/app/src/main/java/unithon/helpjob/data/repository/AuthRepository.kt
+++ b/app/src/main/java/unithon/helpjob/data/repository/AuthRepository.kt
@@ -5,7 +5,10 @@ import unithon.helpjob.data.model.response.TokenResponse
 interface AuthRepository {
     suspend fun signIn(email: String, password: String): TokenResponse
     suspend fun signUp(email: String, password: String): TokenResponse
+
+    @Throws(NicknameDuplicateException::class)
     suspend fun setNickname(nickname: String)
+
     suspend fun setProfile(
         language: String,
         languageLevel: String,

--- a/app/src/main/java/unithon/helpjob/data/repository/DefaultAuthRepository.kt
+++ b/app/src/main/java/unithon/helpjob/data/repository/DefaultAuthRepository.kt
@@ -48,13 +48,23 @@ class DefaultAuthRepository @Inject constructor(
     }
 
     override suspend fun setNickname(nickname: String) {
-        val token = getToken() ?: throw Exception("토큰이 없습니다")
+        val token = getToken() ?: throw UnauthorizedException()
         val response = apiService.setNickname(
             "Bearer $token",
             MemberNicknameReq(nickname)
         )
-        if (!response.isSuccessful) {
-            throw Exception(response.errorBody()?.string() ?: "닉네임 설정 실패")
+
+        if (response.isSuccessful) {
+            return
+        } else {
+            when (response.code()) {
+                409 -> throw NicknameDuplicateException()  // CONFLICT
+                401 -> throw UnauthorizedException()
+                else -> {
+                    val errorBody = response.errorBody()?.string()
+                    throw Exception(errorBody ?: "닉네임 설정 실패")
+                }
+            }
         }
     }
 
@@ -64,7 +74,7 @@ class DefaultAuthRepository @Inject constructor(
         visaType: String,
         industry: String
     ): TokenResponse {
-        val token = getToken() ?: throw Exception("토큰이 없습니다")
+        val token = getToken() ?: throw UnauthorizedException()
         val response = apiService.setProfile(
             "Bearer $token",
             MemberProfileReq(language, languageLevel, visaType, industry)

--- a/app/src/main/java/unithon/helpjob/data/repository/DefaultAuthRepository.kt
+++ b/app/src/main/java/unithon/helpjob/data/repository/DefaultAuthRepository.kt
@@ -48,9 +48,7 @@ class DefaultAuthRepository @Inject constructor(
     }
 
     override suspend fun setNickname(nickname: String) {
-        val token = getToken() ?: throw UnauthorizedException()
         val response = apiService.setNickname(
-            "Bearer $token",
             MemberNicknameReq(nickname)
         )
 
@@ -74,9 +72,7 @@ class DefaultAuthRepository @Inject constructor(
         visaType: String,
         industry: String
     ): TokenResponse {
-        val token = getToken() ?: throw UnauthorizedException()
         val response = apiService.setProfile(
-            "Bearer $token",
             MemberProfileReq(language, languageLevel, visaType, industry)
         )
         if (response.isSuccessful) {

--- a/app/src/main/java/unithon/helpjob/data/repository/Exceptions.kt
+++ b/app/src/main/java/unithon/helpjob/data/repository/Exceptions.kt
@@ -1,0 +1,10 @@
+package unithon.helpjob.data.repository
+
+// 닉네임 중복 예외
+class NicknameDuplicateException : Exception("이미 등록된 닉네임입니다.")
+
+// 인증 관련 예외
+class UnauthorizedException : Exception("인증이 필요합니다.")
+
+// 잘못된 요청 예외
+class BadRequestException(message: String) : Exception(message)

--- a/app/src/main/java/unithon/helpjob/di/NetworkModule.kt
+++ b/app/src/main/java/unithon/helpjob/di/NetworkModule.kt
@@ -12,6 +12,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import unithon.helpjob.BuildConfig
+import unithon.helpjob.data.network.AuthInterceptor
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
@@ -21,8 +22,9 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideOkHttpClient(): OkHttpClient {
+    fun provideOkHttpClient(authInterceptor: AuthInterceptor): OkHttpClient {
         return OkHttpClient.Builder()
+            .addInterceptor(authInterceptor)  // AuthInterceptor 추가
             .addInterceptor(HttpLoggingInterceptor().apply {
                 level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
                 else HttpLoggingInterceptor.Level.NONE

--- a/app/src/main/java/unithon/helpjob/ui/auth/nickname/NicknameSetupScreen.kt
+++ b/app/src/main/java/unithon/helpjob/ui/auth/nickname/NicknameSetupScreen.kt
@@ -75,7 +75,7 @@ fun NicknameSetupScreen(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(top = 4.dp),
+                        .padding(top = 8.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.Top
                 ) {

--- a/app/src/main/java/unithon/helpjob/ui/auth/nickname/NicknameSetupScreen.kt
+++ b/app/src/main/java/unithon/helpjob/ui/auth/nickname/NicknameSetupScreen.kt
@@ -1,0 +1,129 @@
+package unithon.helpjob.ui.auth.nickname
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import unithon.helpjob.R
+import unithon.helpjob.ui.components.HelpJobButton
+import unithon.helpjob.ui.components.HelpJobTextField
+import unithon.helpjob.ui.theme.*
+
+@Composable
+fun NicknameSetupScreen(
+    onNicknameSet: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: NicknameSetupViewModel = hiltViewModel(),
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() }
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    // 닉네임 설정 성공시 네비게이션
+    LaunchedEffect(uiState.isNicknameSet) {
+        if (uiState.isNicknameSet) {
+            onNicknameSet()
+        }
+    }
+
+    // 에러 메시지 처리
+    uiState.userMessage?.let { message ->
+        val snackbarText = stringResource(message)
+        LaunchedEffect(snackbarHostState, viewModel, message, snackbarText) {
+            snackbarHostState.showSnackbar(snackbarText)
+            viewModel.userMessageShown()
+        }
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 20.dp),
+        ) {
+            Spacer(modifier = Modifier.height(80.dp))
+
+            // 제목
+            Text(
+                text = stringResource(id = R.string.nickname_setup_title),
+                style = MaterialTheme.typography.headlineLarge, // 24sp, Bold
+                color = Grey700
+            )
+
+            Spacer(modifier = Modifier.height(39.dp))
+
+            // 닉네임 입력 필드
+            Column {
+                HelpJobTextField(
+                    value = uiState.nickname,
+                    onValueChange = viewModel::updateNickname,
+                    label = "",
+                    placeholder = stringResource(id = R.string.nickname_placeholder),
+                    isError = uiState.nicknameError,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                // 에러 메시지와 글자 수 카운터를 위한 Row
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 4.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.Top
+                ) {
+                    // 에러 메시지 (있을 경우에만 표시)
+                    uiState.nicknameErrorMessage?.let { errorMessage ->
+                        if (uiState.nicknameError) {
+                            Text(
+                                text = stringResource(id = errorMessage),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = Warning,
+                                modifier = Modifier.weight(1f)
+                            )
+                        } else {
+                            Spacer(modifier = Modifier.weight(1f))
+                        }
+                    } ?: Spacer(modifier = Modifier.weight(1f))
+
+                    // 글자 수 카운터 (항상 표시)
+                    Text(
+                        text = stringResource(
+                            id = R.string.nickname_character_count,
+                            uiState.nicknameLength
+                        ),
+                        style = MaterialTheme.typography.labelMedium, // Body4
+                        color = Grey400,
+                        textAlign = TextAlign.End
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // 완료 버튼
+            HelpJobButton(
+                text = stringResource(id = R.string.nickname_complete_button),
+                onClick = viewModel::setNickname,
+                enabled = uiState.isInputValid,
+                isLoading = uiState.isLoading,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 20.dp)
+            )
+        }
+
+        // SnackbarHost 추가
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter)
+        )
+    }
+}

--- a/app/src/main/java/unithon/helpjob/ui/auth/nickname/NicknameSetupViewModel.kt
+++ b/app/src/main/java/unithon/helpjob/ui/auth/nickname/NicknameSetupViewModel.kt
@@ -1,0 +1,104 @@
+package unithon.helpjob.ui.auth.nickname
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import unithon.helpjob.R
+import unithon.helpjob.data.repository.AuthRepository
+import unithon.helpjob.data.repository.NicknameDuplicateException
+import javax.inject.Inject
+
+@HiltViewModel
+class NicknameSetupViewModel @Inject constructor(
+    private val authRepository: AuthRepository
+) : ViewModel() {
+
+    data class NicknameSetupUiState(
+        val nickname: String = "",
+        val nicknameLength: Int = 0,
+        val isLoading: Boolean = false,
+        val userMessage: Int? = null,
+        val isNicknameSet: Boolean = false,
+        val nicknameError: Boolean = false,
+        val nicknameErrorMessage: Int? = null
+    ) {
+        val isInputValid: Boolean
+            get() = nickname.length in 2..10 && !nicknameError
+    }
+
+    private val _uiState = MutableStateFlow(NicknameSetupUiState())
+    val uiState: StateFlow<NicknameSetupUiState> = _uiState.asStateFlow()
+
+    fun updateNickname(nickname: String) {
+        if (nickname.length > 10) return  // 10자 제한
+
+        _uiState.update {
+            it.copy(
+                nickname = nickname,
+                nicknameLength = nickname.length,
+                nicknameError = false,
+                nicknameErrorMessage = null
+            )
+        }
+    }
+
+    fun setNickname() {
+        val currentState = uiState.value
+
+        // 입력 검증
+        when {
+            currentState.nickname.isBlank() -> {
+                _uiState.update {
+                    it.copy(
+                        nicknameError = true,
+                        nicknameErrorMessage = R.string.nickname_empty_error
+                    )
+                }
+                return
+            }
+            currentState.nickname.length < 2 -> {
+                _uiState.update {
+                    it.copy(
+                        nicknameError = true,
+                        nicknameErrorMessage = R.string.nickname_too_short_error
+                    )
+                }
+                return
+            }
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            try {
+                authRepository.setNickname(currentState.nickname)
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        isNicknameSet = true
+                    )
+                }
+            } catch (e: NicknameDuplicateException) {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        nicknameError = true,
+                        nicknameErrorMessage = R.string.nickname_duplicate_error
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        userMessage = R.string.nickname_setup_failed
+                    )
+                }
+            }
+        }
+    }
+
+    fun userMessageShown() {
+        _uiState.update { it.copy(userMessage = null) }
+    }
+}

--- a/app/src/main/java/unithon/helpjob/ui/auth/signin/SignInScreen.kt
+++ b/app/src/main/java/unithon/helpjob/ui/auth/signin/SignInScreen.kt
@@ -106,6 +106,7 @@ fun SignInScreen(
                 onValueChange = viewModel::updatePassword,
                 label = "",
                 visualTransformation = PasswordVisualTransformation(),
+                isError = uiState.passwordError,
                 modifier = Modifier.fillMaxWidth()
             )
 

--- a/app/src/main/java/unithon/helpjob/ui/auth/signin/SignInScreen.kt
+++ b/app/src/main/java/unithon/helpjob/ui/auth/signin/SignInScreen.kt
@@ -102,11 +102,10 @@ fun SignInScreen(
             Spacer(modifier = Modifier.height(9.dp))
 
             HelpJobTextField(
-                value = uiState.email,
-                onValueChange = viewModel::updateEmail,
+                value = uiState.password,
+                onValueChange = viewModel::updatePassword,
                 label = "",
-                isError = uiState.emailError,
-                errorMessage = uiState.emailErrorMessage?.let { stringResource(id = it) },
+                visualTransformation = PasswordVisualTransformation(),
                 modifier = Modifier.fillMaxWidth()
             )
 

--- a/app/src/main/java/unithon/helpjob/ui/auth/signin/SignInScreen.kt
+++ b/app/src/main/java/unithon/helpjob/ui/auth/signin/SignInScreen.kt
@@ -102,11 +102,11 @@ fun SignInScreen(
             Spacer(modifier = Modifier.height(9.dp))
 
             HelpJobTextField(
-                value = uiState.password,
-                onValueChange = viewModel::updatePassword,
+                value = uiState.email,
+                onValueChange = viewModel::updateEmail,
                 label = "",
-                visualTransformation = PasswordVisualTransformation(),
-                isError = uiState.passwordError,
+                isError = uiState.emailError,
+                errorMessage = uiState.emailErrorMessage?.let { stringResource(id = it) },
                 modifier = Modifier.fillMaxWidth()
             )
 

--- a/app/src/main/java/unithon/helpjob/ui/auth/signin/SignInScreen.kt
+++ b/app/src/main/java/unithon/helpjob/ui/auth/signin/SignInScreen.kt
@@ -22,10 +22,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import unithon.helpjob.R
 import unithon.helpjob.ui.components.HelpJobButton
 import unithon.helpjob.ui.components.HelpJobTextField
 import unithon.helpjob.ui.theme.*
@@ -48,9 +50,10 @@ fun SignInScreen(
     }
 
     // 에러 메시지 처리
-    LaunchedEffect(uiState.userMessage) {
-        uiState.userMessage?.let { message ->
-            snackbarHostState.showSnackbar(message)
+    uiState.userMessage?.let { message ->
+        val snackbarText = stringResource(message)
+        LaunchedEffect(snackbarHostState, viewModel, message, snackbarText) {
+            snackbarHostState.showSnackbar(snackbarText)
             viewModel.userMessageShown()
         }
     }
@@ -64,7 +67,7 @@ fun SignInScreen(
         ) {
             // 제목
             Text(
-                text = "환영해요!\n000이 도와드릴게요",
+                text = stringResource(id = R.string.sign_in_welcome_title_default),
                 style = MaterialTheme.typography.headlineLarge, // 24sp, Bold
                 color = Grey700
             )
@@ -73,7 +76,7 @@ fun SignInScreen(
 
             // 이메일 입력
             Text(
-                text = "이메일",
+                text = stringResource(id = R.string.sign_in_email_label),
                 style = MaterialTheme.typography.titleSmall, // 14sp, Bold
                 color = Grey500
             )
@@ -91,7 +94,7 @@ fun SignInScreen(
 
             // 비밀번호 입력
             Text(
-                text = "비밀번호",
+                text = stringResource(id = R.string.sign_in_password_label),
                 style = MaterialTheme.typography.titleSmall, // 14sp, Bold
                 color = Grey500
             )
@@ -110,7 +113,7 @@ fun SignInScreen(
 
             // 로그인 버튼
             HelpJobButton(
-                text = "로그인",
+                text = stringResource(id = R.string.sign_in_button),
                 onClick = viewModel::signIn,
                 enabled = uiState.isInputValid,
                 isLoading = uiState.isLoading,
@@ -136,7 +139,7 @@ fun SignInScreen(
 
                 // 중간 텍스트
                 Text(
-                    text = "또는",
+                    text = stringResource(id = R.string.sign_in_or_divider),
                     style = MaterialTheme.typography.titleSmall,
                     color = Grey300
                 )
@@ -161,13 +164,13 @@ fun SignInScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = "아직 회원이 아니신가요?",
+                    text = stringResource(id = R.string.sign_in_no_account),
                     style = MaterialTheme.typography.bodySmall, // 15sp, Regular
                     color = Grey600
                 )
                 Spacer(modifier = Modifier.width(4.dp))
                 Text(
-                    text = "회원가입",
+                    text = stringResource(id = R.string.sign_in_go_to_sign_up),
                     style = MaterialTheme.typography.titleSmall, // 14sp, Bold
                     color = Primary500,
                     modifier = Modifier.clickable { onNavigateToSignUp() }

--- a/app/src/main/java/unithon/helpjob/ui/auth/signin/SignInViewModel.kt
+++ b/app/src/main/java/unithon/helpjob/ui/auth/signin/SignInViewModel.kt
@@ -19,7 +19,8 @@ class SignInViewModel @Inject constructor(
         val password: String = "",
         val isLoading: Boolean = false,
         val userMessage: Int? = null,
-        val isSignInSuccessful: Boolean = false  // 네비게이션을 위한 플래그
+        val isSignInSuccessful: Boolean = false,  // 네비게이션을 위한 플래그
+        val passwordError: Boolean = false  // 비밀번호 오류 상태
     ) {
         val isInputValid: Boolean
             get() = email.isNotBlank() && password.length >= 6 &&

--- a/app/src/main/java/unithon/helpjob/ui/auth/signin/SignInViewModel.kt
+++ b/app/src/main/java/unithon/helpjob/ui/auth/signin/SignInViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import unithon.helpjob.R
 import unithon.helpjob.data.repository.AuthRepository
 import javax.inject.Inject
 
@@ -17,7 +18,7 @@ class SignInViewModel @Inject constructor(
         val email: String = "",
         val password: String = "",
         val isLoading: Boolean = false,
-        val userMessage: String? = null,
+        val userMessage: Int? = null,
         val isSignInSuccessful: Boolean = false  // 네비게이션을 위한 플래그
     ) {
         val isInputValid: Boolean
@@ -56,7 +57,7 @@ class SignInViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         isLoading = false,
-                        userMessage = e.message ?: "로그인에 실패했습니다"
+                        userMessage = R.string.sign_in_failed
                     )
                 }
             }

--- a/app/src/main/java/unithon/helpjob/ui/auth/signin/SignInViewModel.kt
+++ b/app/src/main/java/unithon/helpjob/ui/auth/signin/SignInViewModel.kt
@@ -58,7 +58,8 @@ class SignInViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         isLoading = false,
-                        userMessage = R.string.sign_in_failed
+                        userMessage = R.string.sign_in_failed,
+                        passwordError = true
                     )
                 }
             }

--- a/app/src/main/java/unithon/helpjob/ui/auth/signup/SignUpScreen.kt
+++ b/app/src/main/java/unithon/helpjob/ui/auth/signup/SignUpScreen.kt
@@ -1,3 +1,136 @@
 package unithon.helpjob.ui.auth.signup
 
-// 회원가입
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import unithon.helpjob.R
+import unithon.helpjob.ui.components.HelpJobButton
+import unithon.helpjob.ui.components.HelpJobTextField
+import unithon.helpjob.ui.theme.*
+
+@Composable
+fun SignUpScreen(
+    onNavigateToSignIn: () -> Unit,
+    onNavigateToOnboarding: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: SignUpViewModel = hiltViewModel(),
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() }
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    // 회원가입 성공시 네비게이션
+    LaunchedEffect(uiState.isSignUpSuccessful) {
+        if (uiState.isSignUpSuccessful) {
+            onNavigateToOnboarding()
+        }
+    }
+
+    // 에러 메시지 처리
+    uiState.userMessage?.let { message ->
+        val snackbarText = stringResource(message)
+        LaunchedEffect(snackbarHostState, viewModel, message, snackbarText) {
+            snackbarHostState.showSnackbar(snackbarText)
+            viewModel.userMessageShown()
+        }
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 20.dp),
+        ) {
+            Spacer(modifier = Modifier.height(80.dp))
+
+            // 제목
+            Text(
+                text = stringResource(id = R.string.sign_up_title),
+                style = MaterialTheme.typography.headlineLarge, // 24sp, Bold
+                color = Grey700
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // 부제목
+            Text(
+                text = stringResource(id = R.string.sign_up_subtitle),
+                style = MaterialTheme.typography.titleMedium, // 16sp, Bold (Title1)
+                color = Grey500
+            )
+
+            Spacer(modifier = Modifier.height(40.dp))
+
+            // 이메일 레이블
+            Text(
+                text = stringResource(id = R.string.sign_up_email_label),
+                style = MaterialTheme.typography.titleSmall, // 14sp, Bold
+                color = Grey500
+            )
+
+            Spacer(modifier = Modifier.height(9.dp))
+
+            // 이메일 입력 필드
+            HelpJobTextField(
+                value = uiState.email,
+                onValueChange = viewModel::updateEmail,
+                label = "",
+                placeholder = stringResource(id = R.string.sign_up_email_hint),
+                isError = uiState.emailError,
+                errorMessage = uiState.emailErrorMessage?.let { stringResource(id = it) },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            // 비밀번호 레이블
+            Text(
+                text = stringResource(id = R.string.sign_up_password_label),
+                style = MaterialTheme.typography.titleSmall, // 14sp, Bold
+                color = Grey500
+            )
+
+            Spacer(modifier = Modifier.height(9.dp))
+
+            // 비밀번호 입력 필드
+            HelpJobTextField(
+                value = uiState.password,
+                onValueChange = viewModel::updatePassword,
+                label = "",
+                placeholder = stringResource(id = R.string.sign_up_password_hint),
+                visualTransformation = PasswordVisualTransformation(),
+                isError = uiState.passwordError,
+                errorMessage = uiState.passwordErrorMessage?.let { stringResource(id = it) },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // 다음 버튼
+            HelpJobButton(
+                text = stringResource(id = R.string.sign_up_next_button),
+                onClick = viewModel::signUp,
+                enabled = uiState.isInputValid,
+                isLoading = uiState.isLoading,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 20.dp)
+            )
+        }
+
+        // SnackbarHost 추가
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter)
+        )
+    }
+}

--- a/app/src/main/java/unithon/helpjob/ui/auth/signup/SignUpScreen.kt
+++ b/app/src/main/java/unithon/helpjob/ui/auth/signup/SignUpScreen.kt
@@ -20,8 +20,7 @@ import unithon.helpjob.ui.theme.*
 
 @Composable
 fun SignUpScreen(
-    onNavigateToSignIn: () -> Unit,
-    onNavigateToOnboarding: () -> Unit,
+    onNavigateToNicknameSetup: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SignUpViewModel = hiltViewModel(),
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() }
@@ -31,7 +30,7 @@ fun SignUpScreen(
     // 회원가입 성공시 네비게이션
     LaunchedEffect(uiState.isSignUpSuccessful) {
         if (uiState.isSignUpSuccessful) {
-            onNavigateToOnboarding()
+            onNavigateToNicknameSetup()
         }
     }
 

--- a/app/src/main/java/unithon/helpjob/ui/auth/signup/SignUpViewModel.kt
+++ b/app/src/main/java/unithon/helpjob/ui/auth/signup/SignUpViewModel.kt
@@ -1,0 +1,131 @@
+package unithon.helpjob.ui.auth.signup
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import unithon.helpjob.R
+import unithon.helpjob.data.repository.AuthRepository
+import javax.inject.Inject
+
+@HiltViewModel
+class SignUpViewModel @Inject constructor(
+    private val authRepository: AuthRepository
+) : ViewModel() {
+
+    data class SignUpUiState(
+        val email: String = "",
+        val password: String = "",
+        val isLoading: Boolean = false,
+        val userMessage: Int? = null,
+        val isSignUpSuccessful: Boolean = false,
+        val emailError: Boolean = false,
+        val passwordError: Boolean = false,
+        val emailErrorMessage: Int? = null,
+        val passwordErrorMessage: Int? = null
+    ) {
+        val isInputValid: Boolean
+            get() = email.isNotBlank() && password.length >= 6 &&
+                    android.util.Patterns.EMAIL_ADDRESS.matcher(email).matches()
+    }
+
+    private val _uiState = MutableStateFlow(SignUpUiState())
+    val uiState: StateFlow<SignUpUiState> = _uiState.asStateFlow()
+
+    fun updateEmail(email: String) {
+        _uiState.update {
+            it.copy(
+                email = email,
+                emailError = false,
+                emailErrorMessage = null
+            )
+        }
+    }
+
+    fun updatePassword(password: String) {
+        _uiState.update {
+            it.copy(
+                password = password,
+                passwordError = false,
+                passwordErrorMessage = null
+            )
+        }
+    }
+
+    fun signUp() {
+        val currentState = uiState.value
+
+        // 입력 검증
+        var hasError = false
+
+        if (currentState.email.isBlank()) {
+            _uiState.update {
+                it.copy(
+                    emailError = true,
+                    emailErrorMessage = R.string.error_empty_email
+                )
+            }
+            hasError = true
+        } else if (!android.util.Patterns.EMAIL_ADDRESS.matcher(currentState.email).matches()) {
+            _uiState.update {
+                it.copy(
+                    emailError = true,
+                    emailErrorMessage = R.string.error_invalid_email
+                )
+            }
+            hasError = true
+        }
+
+        if (currentState.password.isBlank()) {
+            _uiState.update {
+                it.copy(
+                    passwordError = true,
+                    passwordErrorMessage = R.string.error_empty_password
+                )
+            }
+            hasError = true
+        } else if (currentState.password.length < 6) {
+            _uiState.update {
+                it.copy(
+                    passwordError = true,
+                    passwordErrorMessage = R.string.error_short_password
+                )
+            }
+            hasError = true
+        }
+
+        if (hasError) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            try {
+                authRepository.signUp(
+                    email = currentState.email,
+                    password = currentState.password
+                )
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        isSignUpSuccessful = true
+                    )
+                }
+            } catch (e: Exception) {
+                val errorMessage = when {
+                    e.message?.contains("already exists") == true -> R.string.sign_up_email_exists
+                    else -> R.string.sign_up_failed
+                }
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        userMessage = errorMessage
+                    )
+                }
+            }
+        }
+    }
+
+    fun userMessageShown() {
+        _uiState.update { it.copy(userMessage = null) }
+    }
+}

--- a/app/src/main/java/unithon/helpjob/ui/components/HelpJobTextField.kt
+++ b/app/src/main/java/unithon/helpjob/ui/components/HelpJobTextField.kt
@@ -52,8 +52,9 @@ fun HelpJobTextField(
                 color = Grey700 // 입력값 텍스트 색상
             ),
             colors = OutlinedTextFieldDefaults.colors(
-                unfocusedBorderColor = Grey200,
-                focusedBorderColor = Primary500,
+                unfocusedBorderColor = if (isError) Warning else Grey200,
+                focusedBorderColor = if (isError) Warning else Primary500,
+                errorBorderColor = Warning,
                 cursorColor = Primary500,
                 unfocusedContainerColor = Grey000,
                 focusedContainerColor = Grey000,

--- a/app/src/main/java/unithon/helpjob/ui/components/HelpJobTextField.kt
+++ b/app/src/main/java/unithon/helpjob/ui/components/HelpJobTextField.kt
@@ -3,6 +3,7 @@ package unithon.helpjob.ui.components
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
@@ -61,7 +62,7 @@ fun HelpJobTextField(
             ),
             modifier = Modifier
                 .fillMaxWidth()
-                .height(46.dp)
+                .heightIn(min = 48.dp)
         )
 
         if (isError && errorMessage != null) {

--- a/app/src/main/java/unithon/helpjob/ui/components/HelpJobTextField.kt
+++ b/app/src/main/java/unithon/helpjob/ui/components/HelpJobTextField.kt
@@ -42,7 +42,16 @@ fun HelpJobTextField(
         OutlinedTextField(
             value = value,
             onValueChange = onValueChange,
-            placeholder = null, // placeholder 제거
+            placeholder = if (placeholder.isNotBlank()) {
+                {
+                    Text(
+                        text = placeholder,
+                        style = MaterialTheme.typography.titleSmall.copy(
+                            color = Grey300 // placeholder 색상
+                        )
+                    )
+                }
+            } else null,
             visualTransformation = visualTransformation,
             keyboardOptions = keyboardOptions,
             isError = isError,

--- a/app/src/main/java/unithon/helpjob/util/ComposeUtils.kt
+++ b/app/src/main/java/unithon/helpjob/util/ComposeUtils.kt
@@ -1,0 +1,21 @@
+package unithon.helpjob.util
+
+//import androidx.compose.runtime.Composable
+//import androidx.compose.ui.Modifier
+//
+///**
+// * 화면의 로딩 상태와 빈 상태를 관리하는 유틸리티
+// */
+//@Composable
+//fun LoadingContent(
+//    loading: Boolean,
+//    empty: Boolean,
+//    emptyContent: @Composable () -> Unit,
+//    modifier: Modifier = Modifier,
+//    content: @Composable () -> Unit
+//) {
+//    when {
+//        empty -> emptyContent()
+//        else -> content()
+//    }
+//}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,17 @@
     <string name="sign_up_failed">회원가입에 실패했습니다</string>
     <string name="sign_up_email_exists">이미 존재하는 이메일입니다</string>
 
+    <!-- Nickname Setup Screen -->
+    <string name="nickname_setup_title">OOO 에서 사용할\n닉네임을 설정해주세요</string>
+    <string name="nickname_placeholder">닉네임을 입력해주세요</string>
+    <string name="nickname_character_count">%1$d / 10</string>
+    <string name="nickname_duplicate_error">ⓘ 이미 사용 중인 닉네임이에요.</string>
+    <string name="nickname_complete_button">완료</string>
+    <string name="nickname_empty_error">닉네임을 입력해주세요</string>
+    <string name="nickname_too_short_error">닉네임은 2자 이상이어야 합니다</string>
+    <string name="nickname_too_long_error">닉네임은 10자 이하여야 합니다</string>
+    <string name="nickname_setup_failed">닉네임 설정에 실패했습니다</string>
+
     <!-- Common Error Messages -->
     <string name="error_empty_email">이메일을 입력해주세요</string>
     <string name="error_invalid_email">올바른 이메일 형식이 아닙니다</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,16 +16,16 @@
 
     <!-- SignUp Screen -->
     <string name="sign_up_title">회원가입</string>
+    <string name="sign_up_subtitle">간단한 정보를 입력해주세요!</string>
+    <string name="sign_up_email_label">이메일</string>
+    <string name="sign_up_email_hint">이메일을 입력해주세요</string>
+    <string name="sign_up_password_label">비밀번호</string>
+    <string name="sign_up_password_hint">비밀번호를 입력해주세요</string>
+    <string name="sign_up_next_button">다음</string>
+    <string name="sign_up_failed">회원가입에 실패했습니다</string>
+    <string name="sign_up_email_exists">이미 존재하는 이메일입니다</string>
 
-    <!-- Onboarding Screen -->
-    <string name="onboarding_title">시작하기</string>
-
-    <!-- Main/Temp Screen -->
-    <string name="temp_login_success">로그인 성공!</string>
-    <string name="temp_main_description">임시 메인 화면입니다</string>
-    <string name="temp_logout">로그아웃</string>
-
-    <!-- Common -->
+    <!-- Common Error Messages -->
     <string name="error_empty_email">이메일을 입력해주세요</string>
     <string name="error_invalid_email">올바른 이메일 형식이 아닙니다</string>
     <string name="error_empty_password">비밀번호를 입력해주세요</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,33 @@
 <resources>
     <string name="app_name">HelpJob</string>
+
+    <!-- SignIn Screen -->
+    <string name="sign_in_welcome_title">환영해요!\n%s이 도와드릴게요</string>
+    <string name="sign_in_welcome_title_default">환영해요!\nOOO이 도와드릴게요</string>
+    <string name="sign_in_email_label">이메일</string>
+    <string name="sign_in_password_label">비밀번호</string>
+    <string name="sign_in_button">로그인</string>
+    <string name="sign_in_or_divider">또는</string>
+    <string name="sign_in_no_account">아직 회원이 아니신가요?</string>
+    <string name="sign_in_go_to_sign_up">회원가입</string>
+
+    <!-- SignIn Error Messages -->
+    <string name="sign_in_failed">로그인에 실패했습니다</string>
+
+    <!-- SignUp Screen -->
+    <string name="sign_up_title">회원가입</string>
+
+    <!-- Onboarding Screen -->
+    <string name="onboarding_title">시작하기</string>
+
+    <!-- Main/Temp Screen -->
+    <string name="temp_login_success">로그인 성공!</string>
+    <string name="temp_main_description">임시 메인 화면입니다</string>
+    <string name="temp_logout">로그아웃</string>
+
+    <!-- Common -->
+    <string name="error_empty_email">이메일을 입력해주세요</string>
+    <string name="error_invalid_email">올바른 이메일 형식이 아닙니다</string>
+    <string name="error_empty_password">비밀번호를 입력해주세요</string>
+    <string name="error_short_password">비밀번호는 6자 이상이어야 합니다</string>
 </resources>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -2,6 +2,6 @@
 <network-security-config>
     <!-- 개발 단계에서만 사용 -->
     <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">ec2-3-36-114-182.ap-northeast-2.compute.amazonaws.com</domain>
+        <domain includeSubdomains="true">3.36.2.85</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
## 구현 내용

- 로그인 화면 UI (피그마 디자인 적용)
- 회원가입 화면 UI 구현
- 닉네임 설정 화면 UI 구현
- 인증 관련 API 연동 (로그인, 회원가입, 닉네임 설정)
- 토큰 관리 자동화 (AuthInterceptor)
- 인증 플로우 네비게이션 구성

## 추가된 것들

- 디자인 시스템 (Color, Typography)
- 공통 컴포넌트 (HelpJobButton, HelpJobTextField)
- AuthRepository (인증 관련 API 통합)
- 각 화면의 ViewModel (SignIn, SignUp, NicknameSetup)
- 에러 처리 강화 (필드별 개별 에러 메시지)
- 문자열 리소스화 (하드코딩 제거)